### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,23 +6,23 @@
 # Datatypes (KEYWORD1)
 ###########################################
 
-TimeOBJ     KEYWORD1
+TimeOBJ	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
-add         KEYWORD2
-sub         KEYWORD2
-get         KEYWORD2
-print       KEYWORD2
+add	KEYWORD2
+sub	KEYWORD2
+get	KEYWORD2
+print	KEYWORD2
 
 ###########################################
 # Constants (LITERAL1)
 ###########################################
-YEAR        LITERAL1
-DAY         LITERAL1
-HOUR        LITERAL1
-MINUTE      LITERAL1
-SECONDE     LITERAL1
-MILLI       LITERAL1
-MICRO       LITERAL1
+YEAR	LITERAL1
+DAY	LITERAL1
+HOUR	LITERAL1
+MINUTE	LITERAL1
+SECONDE	LITERAL1
+MILLI	LITERAL1
+MICRO	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords